### PR TITLE
Fix collection of treeCtrl in editfeatureselector and snapping

### DIFF
--- a/contribs/gmf/src/directives/editfeatureselector.js
+++ b/contribs/gmf/src/directives/editfeatureselector.js
@@ -130,17 +130,21 @@ gmf.EditfeatureselectorController = function($scope, $timeout, gmfThemes,
    * @param {Array.<ngeo.LayertreeController>} value First level controllers.
    */
   var updateEditableTreeCtrls = function(value) {
-    if (value) {
-      var editables = this.editableTreeCtrls;
+    // Timeout required, because the collection event is fired before the
+    // leaf nodes are created and they are the ones we're looking for here.
+    this.$timeout_(function() {
+      if (value) {
+        var editables = this.editableTreeCtrls;
 
-      editables.length = 0;
-      this.gmfTreeManager_.rootCtrl.traverseDepthFirst(function(treeCtrl) {
-        if (treeCtrl.node.editable) {
-          goog.asserts.assert(treeCtrl.children.length === 0);
-          editables.push(treeCtrl);
-        }
-      });
-    }
+        editables.length = 0;
+        this.gmfTreeManager_.rootCtrl.traverseDepthFirst(function(treeCtrl) {
+          if (treeCtrl.node.editable) {
+            goog.asserts.assert(treeCtrl.children.length === 0);
+            editables.push(treeCtrl);
+          }
+        });
+      }
+    }.bind(this), 0);
   };
 
   /**

--- a/contribs/gmf/src/services/snapping.js
+++ b/contribs/gmf/src/services/snapping.js
@@ -162,10 +162,14 @@ gmf.Snapping.prototype.setMap = function(map) {
         return this.gmfTreeManager_.rootCtrl.children;
       }
     }.bind(this), function(value) {
-      if (value) {
-        this.unregisterAllTreeCtrl_();
-        this.gmfTreeManager_.rootCtrl.traverseDepthFirst(this.registerTreeCtrl_.bind(this));
-      }
+      // Timeout required, because the collection event is fired before the
+      // leaf nodes are created and they are the ones we're looking for here.
+      this.timeout_(function() {
+        if (value) {
+          this.unregisterAllTreeCtrl_();
+          this.gmfTreeManager_.rootCtrl.traverseDepthFirst(this.registerTreeCtrl_.bind(this));
+        }
+      }.bind(this), 0);
     }.bind(this));
 
     keys.push(


### PR DESCRIPTION
An issue occurs when watching the layertree root children: the 'watchCollection' event gets fired before the child nodes are created, and those are the ones we're looking for in the editfeatureselector directive and the snapping service.

This PR introduces a timeout of 0ms to allow them to be created before executing the rest of the code that fetches the nodes.
